### PR TITLE
Write registry contract

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,8 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-utils>=1,<2",
-        "ethpm==0.1.3a6",
-        "pytest-ethereum>=0.1.2,<2",
+        "ethpm==0.1.3a7",
+        "pytest-ethereum==0.1.2-alpha.3",
         "web3[tester]==4.4.1",
     ],
     setup_requires=['setuptools-markdown'],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+from twig import CONTRACTS_DIR
 from web3 import Web3
 
 TEST_CONTRACTS_DIR = Path(__file__).parent / "contracts"
@@ -22,3 +23,8 @@ def tmp_contracts(tmpdir):
         tmp = p.join(contract.name)
         tmp.write(contract.read_text())
     return p
+
+
+@pytest.fixture
+def deployer(twig_deployer):
+    return twig_deployer(CONTRACTS_DIR)

--- a/tests/core/test_compiler.py
+++ b/tests/core/test_compiler.py
@@ -33,22 +33,21 @@ def test_compiler(compiler):
     assert isinstance(compiler.backend, VyperBackend)
 
 
-def test_compiler_creates_valid_registry_package_and_deployment(twig_deployer):
-    registry_package, address = twig_deployer.deploy("registry")
-    w3 = registry_package.w3
-    registry_contract = registry_package.get_contract_instance("registry", address)
+def test_compiler_creates_valid_registry_package_and_deployment(twig_deployer, w3):
+    registry_package = twig_deployer.deploy("registry")
+    registry_contract = registry_package.deployments.get_contract_instance("registry")
     registry_contract.functions.register(b"xxx", w3.eth.accounts[0]).transact()
     actual = registry_contract.functions.lookup(b"xxx").call()
     assert actual == w3.eth.accounts[0]
 
 
 def test_compiler_creates_valid_auction_package_and_deployment(twig_deployer, w3):
-    auction_package, address = twig_deployer.deploy(
+    auction_package = twig_deployer.deploy(
         "simple_open_auction", w3.eth.accounts[0], 100
     )
     w3 = auction_package.w3
-    auction_contract = auction_package.get_contract_instance(
-        "simple_open_auction", address
+    auction_contract = auction_package.deployments.get_contract_instance(
+        "simple_open_auction"
     )
     auction_start = auction_contract.functions.auction_start().call()
     auction_end = auction_contract.functions.auction_end().call()

--- a/tests/core/test_registry_contract.py
+++ b/tests/core/test_registry_contract.py
@@ -1,0 +1,154 @@
+import logging
+
+import pytest
+
+import pytest_ethereum as pte
+from pytest_ethereum.testing import Log
+
+PACKAGE_ID = b'\xd0Y\xe8\xa6\xeaZ\x8b\xbf\x8d\xd0\x97\xa7\xb8\x92#\x16\xdc\xb7\xf0$\xe8"\x0bV\xd3\xc9\xe7\x18\x8ajv@'  # noqa: E501
+V1_RELEASE_ID = b"Y^&\xf1\xb2${\xac\xc5~2\x80\x7f\x80Y\xe0\xb0\x83}\xd9\xc4~iF\x99A\x96\xbd)\xc9\xca\x97"  # noqa: E501
+V2_RELEASE_ID = b"\x04Y,\xb9\xce\xd5A>\x1b\t\xe8{\x08\x9b\xf6\x96\xa0^\xfbv\xee\x87\xc8\xc4\x12Yc_\xacm\x93\x8a"  # noqa: E501
+
+logging.getLogger("evm").setLevel(logging.INFO)
+
+
+@pytest.fixture
+def registry(deployer):
+    pkg = deployer.deploy("registry")
+    return pkg.deployments.get_contract_instance("registry")
+
+
+def test_registry_init(registry, w3):
+    assert registry.functions.owner().call() == w3.eth.accounts[0]
+
+
+def test_registry_generate_release_id(registry):
+    release_id = registry.functions.generate_release_id(b"package", b"1.0.0").call()
+    assert release_id == V1_RELEASE_ID
+
+
+def test_registry_release(registry):
+    release_id = registry.functions.release(b"package", b"1.0.0", b"google.com").call()
+    assert release_id == V1_RELEASE_ID
+
+
+def test_registry_get_package_data_raises_exception_if_package_doesnt_exist(registry):
+    with pte.tx_fail():
+        registry.functions.get_package_data(PACKAGE_ID).call()
+
+
+def test_registry_get_package_data(registry, w3):
+    registry.functions.release(b"package", b"1.0.0", b"google.com").transact()
+    package_data = registry.functions.get_package_data(PACKAGE_ID).call()
+    assert package_data[0][:7] == b"package"
+    assert package_data[1] == 1
+    tx_hash = registry.functions.release(b"package", b"1.0.1", b"google.com").transact()
+    w3.eth.waitForTransactionReceipt(tx_hash)
+    package_data_2 = registry.functions.get_package_data(PACKAGE_ID).call()
+    assert package_data_2[0][:7] == b"package"
+    assert package_data_2[1] == 2
+
+
+def test_registry_get_release_id_by_package_and_count(registry):
+    registry.functions.release(b"package", b"1.0.0", b"google.com").transact()
+    registry.functions.release(b"package", b"1.0.1", b"google.com").transact()
+    release_id_1 = registry.functions.get_release_id_by_package_and_count(
+        b"package", 1
+    ).call()
+    release_id_2 = registry.functions.get_release_id_by_package_and_count(
+        b"package", 2
+    ).call()
+    assert release_id_1 == V1_RELEASE_ID
+    assert release_id_2 == V2_RELEASE_ID
+    with pte.tx_fail():
+        registry.functions.get_release_id_by_package_and_count(b"package", 3).call()
+
+
+def test_registry_logs_release_event(registry, w3):
+    tx_hash = registry.functions.release(b"package", b"1.0.0", b"google.com").transact()
+    receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+    assert Log(
+        registry.events.Release,
+        _package=b"package",
+        _version=b"1.0.0",
+        _uri=b"google.com",
+    ).exact_match(receipt)
+
+
+def test_registry_get_release_data(registry):
+    registry.functions.release(b"package", b"1.0.0", b"google.com").transact()
+    release_data = registry.functions.get_release_data(V1_RELEASE_ID).call()
+    assert release_data[0][:7] == b"package"
+    assert release_data[1][:5] == b"1.0.0"
+    assert release_data[2][:10] == b"google.com"
+
+
+def test_registry_release_auth(registry, w3):
+    registry.functions.release(b"package", b"1.0.0", b"google.com").transact()
+    with pte.tx_fail():
+        registry.functions.release(b"package", b"1.0.1", b"googlex.com").transact(
+            {"from": w3.eth.accounts[1]}
+        )
+
+
+def test_cannot_release_different_uri_for_same_version(registry):
+    registry.functions.release(b"package", b"1.0.0", b"google.com").transact()
+    with pte.tx_fail():
+        registry.functions.release(b"package", b"1.0.0", b"googlex.com").transact()
+
+
+def test_registry_update_release(registry):
+    registry.functions.release(b"package", b"1.0.0", b"google.com").transact()
+    registry.functions.release(b"package", b"1.0.1", b"yahoo.com").transact()
+    release_data = registry.functions.get_release_data(V2_RELEASE_ID).call()
+    assert release_data[0][:7] == b"package"
+    assert release_data[1][:5] == b"1.0.1"
+    assert release_data[2][:9] == b"yahoo.com"
+
+
+@pytest.mark.parametrize(
+    "args",
+    (
+        (b"package", b"", b"google.com"),
+        (b"", b"1.0.0", b"google.com"),
+        (b"package", b"1.0.0", b""),
+    ),
+)
+def test_release_with_empty_values_raises_exception(registry, args):
+    with pte.tx_fail():
+        registry.functions.release(*args).transact()
+
+
+def test_registry_transfer_owner(registry, w3):
+    registry.functions.release(b"package", b"1.0.0", b"google.com").transact()
+    release_count = registry.functions.release_count().call()
+    assert release_count == 1
+    registry.functions.transfer_owner(w3.eth.accounts[1]).transact()
+    w3.testing.mine(1)
+    owner = registry.functions.owner().call()
+    assert owner == w3.eth.accounts[1]
+    # test you cannot release unless from owner
+    with pte.tx_fail():
+        registry.functions.release(b"package", b"1.0.1", b"yahoo.com").transact()
+    registry.functions.release(b"package", b"1.0.1", b"yahoo.com").transact(
+        {"from": w3.eth.accounts[1]}
+    )
+    release_count = registry.functions.release_count().call()
+    assert release_count == 2
+
+
+def test_registry_get_all_package_ids(registry):
+    registry.functions.release(b"package", b"1.0.0", b"google.com").transact()
+    registry.functions.release(b"package", b"1.0.1", b"yahoo.com").transact()
+    registry.functions.release(b"package1", b"1.0.0", b"espn.com").transact()
+    registry.functions.release(b"package2", b"1.0.0", b"cnn.com").transact()
+    package_count = registry.functions.package_count().call()
+    release_count = registry.functions.release_count().call()
+    assert package_count == 3
+    assert release_count == 4
+    package_id_0 = registry.functions.get_package_id(0).call()
+    release_id_0 = registry.functions.get_release_id(0).call()
+    release_id_1 = registry.functions.get_release_id(1).call()
+    assert package_id_0 == PACKAGE_ID
+    assert release_id_0 == V1_RELEASE_ID
+    assert release_id_1 == V2_RELEASE_ID

--- a/tests/core/test_registry_contract.py
+++ b/tests/core/test_registry_contract.py
@@ -39,12 +39,11 @@ def test_registry_get_package_data_raises_exception_if_package_doesnt_exist(regi
 
 def test_registry_get_package_data(registry, w3):
     registry.functions.release(b"package", b"1.0.0", b"google.com").transact()
-    package_data = registry.functions.get_package_data(PACKAGE_ID).call()
+    package_data = registry.functions.get_package_data(b'package').call()
     assert package_data[0][:7] == b"package"
     assert package_data[1] == 1
-    tx_hash = registry.functions.release(b"package", b"1.0.1", b"google.com").transact()
-    w3.eth.waitForTransactionReceipt(tx_hash)
-    package_data_2 = registry.functions.get_package_data(PACKAGE_ID).call()
+    registry.functions.release(b"package", b"1.0.1", b"google.com").transact()
+    package_data_2 = registry.functions.get_package_data(b'package').call()
     assert package_data_2[0][:7] == b"package"
     assert package_data_2[1] == 2
 
@@ -77,7 +76,7 @@ def test_registry_logs_release_event(registry, w3):
 
 def test_registry_get_release_data(registry):
     registry.functions.release(b"package", b"1.0.0", b"google.com").transact()
-    release_data = registry.functions.get_release_data(V1_RELEASE_ID).call()
+    release_data = registry.functions.get_release_data(b'package', b'1.0.0').call()
     assert release_data[0][:7] == b"package"
     assert release_data[1][:5] == b"1.0.0"
     assert release_data[2][:10] == b"google.com"
@@ -100,7 +99,7 @@ def test_cannot_release_different_uri_for_same_version(registry):
 def test_registry_update_release(registry):
     registry.functions.release(b"package", b"1.0.0", b"google.com").transact()
     registry.functions.release(b"package", b"1.0.1", b"yahoo.com").transact()
-    release_data = registry.functions.get_release_data(V2_RELEASE_ID).call()
+    release_data = registry.functions.get_release_data(b'package', b'1.0.1').call()
     assert release_data[0][:7] == b"package"
     assert release_data[1][:5] == b"1.0.1"
     assert release_data[2][:9] == b"yahoo.com"

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,6 @@ whitelist_externals=make
 basepython=python
 extras=lint
 commands=
-    flake8 {toxinidir}/twig {toxinidir}/tests
+    flake8 {toxinidir}/twig {toxinidir}/tests --exclude twig/contracts/
     black --check --diff {toxinidir}/twig/ --check --diff {toxinidir}/tests/
     isort --recursive {toxinidir}/twig {toxinidir}/tests

--- a/twig/contracts/registry.v.py
+++ b/twig/contracts/registry.v.py
@@ -1,0 +1,183 @@
+# Events
+Release: event({_package: indexed(bytes32), _version: bytes32, _uri: bytes32})
+
+owner: public(address)
+
+# Package Data: (package_id => value)
+packages: public(
+    {
+        exists: bool,
+        created_at: timestamp,
+        updated_at: timestamp,
+        name: bytes32,
+        release_count: int128,
+    }[bytes32]
+)
+
+#  Release Data: (release_id => value)
+releases: public(
+    {
+        exists: bool,
+        created_at: timestamp,
+        package_id: bytes32,
+        version: bytes32,
+        uri: bytes32,
+    }[bytes32]
+)
+
+
+# package_id#release_count => release_id
+package_release_index: bytes32[bytes32]
+# Total number of packages in registry
+package_count: public(int128)
+# Total number of releases in registry
+release_count: public(int128)
+# Total package number (int128) => package_id (bytes32)
+package_ids: bytes32[int128]
+# Total release number (int128) => release_id (bytes32)
+release_ids: bytes32[int128]
+
+EMPTY_BYTES: bytes32
+
+
+@public
+def __init__():
+    self.owner = msg.sender
+
+
+@public
+def transfer_owner(new_owner: address):
+    """
+    Change ownership of contract.
+    """
+    assert self.owner == msg.sender
+    self.owner = new_owner
+
+
+@public
+def generate_release_id(name: bytes32, version: bytes32) -> bytes32:
+    """
+    Return the `release_id` associated with a given package name and release version.
+    """
+    release_concat: bytes[64] = concat(name, version)
+    release_id: bytes32 = sha3(release_concat)
+    return release_id
+
+
+@public
+def get_package_data(package_id: bytes32) -> (bytes32, int128):
+    """
+    Return a package name and release count associated with a given `package_id`.
+    """
+    assert self.packages[package_id].exists == True
+    return (self.packages[package_id].name, self.packages[package_id].release_count)
+
+
+@public
+def get_release_data(release_id: bytes32) -> (bytes32, bytes32, bytes32):
+    """
+    Return package name, release version, and manifest uri associated with a given `release_id`.
+    """
+    assert self.releases[release_id].exists == True
+    package_name: bytes32 = self.packages[self.releases[release_id].package_id].name
+    version: bytes32 = self.releases[release_id].version
+    uri: bytes32 = self.releases[release_id].uri
+    return (package_name, version, uri)
+
+
+@public
+def get_package_id(index: int128) -> bytes32:
+    """
+    Return the `package_id` associated with the package identified by the given index.
+    """
+    assert index <= self.package_count
+    return self.package_ids[index]
+
+
+@public
+def get_release_id(index: int128) -> bytes32:
+    """
+    Return the `release_id` associated with the release identified by the given index.
+    """
+    assert index <= self.release_count
+    return self.release_ids[index]
+
+
+@private
+def generate_package_release_id(package_id: bytes32, count: int128) -> bytes32:
+    count_bytes: bytes32 = convert(count, "bytes32")
+    package_release_tag: bytes[64] = concat(package_id, count_bytes)
+    package_release_id: bytes32 = sha3(package_release_tag)
+    return package_release_id
+
+
+@public
+def get_release_id_by_package_and_count(name: bytes32, count: int128) -> bytes32:
+    """
+    Return the `release_id` associated with a given package name and release count.
+    """
+    package_id: bytes32 = sha3(name)
+    assert self.packages[package_id].exists
+    assert count <= self.packages[package_id].release_count
+    package_release_id: bytes32 = self.generate_package_release_id(package_id, count)
+    return self.package_release_index[package_release_id]
+
+
+@private
+def cut_release(
+    release_id: bytes32,
+    package_id: bytes32,
+    version: bytes32,
+    uri: bytes32,
+    name: bytes32,
+):
+    self.releases[release_id] = {
+        exists: True,
+        created_at: block.timestamp,
+        package_id: package_id,
+        version: version,
+        uri: uri,
+    }
+    self.packages[package_id].release_count += 1
+    self.release_ids[self.release_count] = release_id
+    self.release_count += 1
+    package_release_id: bytes32 = self.generate_package_release_id(
+        package_id, self.packages[package_id].release_count
+    )
+    self.package_release_index[package_release_id] = release_id
+    log.Release(name, version, uri)
+
+
+@public
+def release(name: bytes32, version: bytes32, uri: bytes32) -> bytes32:
+    assert uri != self.EMPTY_BYTES
+    assert name != self.EMPTY_BYTES
+    assert version != self.EMPTY_BYTES
+    assert self.owner == msg.sender
+
+    package_id: bytes32 = sha3(name)
+    release_id: bytes32 = self.generate_release_id(name, version)
+
+    if self.packages[package_id].exists == True:
+        self.packages[package_id] = {
+            exists: True,
+            created_at: self.packages[package_id].created_at,
+            updated_at: block.timestamp,
+            name: name,
+            release_count: self.packages[package_id].release_count,
+        }
+        assert self.releases[release_id].exists == False
+        self.cut_release(release_id, package_id, version, uri, name)
+        return release_id
+    else:
+        self.packages[package_id] = {
+            exists: True,
+            created_at: block.timestamp,
+            updated_at: block.timestamp,
+            name: name,
+            release_count: 0,
+        }
+        self.package_ids[self.package_count] = package_id
+        self.package_count += 1
+        self.cut_release(release_id, package_id, version, uri, name)
+        return release_id


### PR DESCRIPTION
## What was wrong?
Vyper Registry contract - following [ERC-1319](https://github.com/ethereum/EIPs/issues/1319)
Including the `registry.v.py` contract in `/contracts/` for now, with plans to yank it out or move it to `/tests/` later

@fubuloubu @jacqueswww @davesque Would love some feedback on the contract / testing. It's still a WIP as there is plenty of room for improvements

some concerns:
- Right now max # of packages/releases allowed per registry = 128 (number is irrelevant, but i'm still looking for a way to improve this - variable length arrays are not possible, correct?)
- docs nonexistent, but coming soon

CI won't pass until https://github.com/ethereum/pytest-ethereum/pull/11 is merged and released

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/46545053-2230f800-c87a-11e8-8349-c248826c2f59.png)

