### PR TITLE
Use new vyper compiler interface.

### DIFF
--- a/twig/backends/vyper.py
+++ b/twig/backends/vyper.py
@@ -18,5 +18,5 @@ def generate_vyper_compiler_output(
     for source in all_sources:
         contract_file = str(source).split("/")[-1]
         contract_type = contract_file.split(".")[0]
-        # todo fix to accomodate multiple types in a single contract file
+        # todo fix to accomodate multiple types in a single contract file.
         yield str(source), {contract_type: create_raw_asset_data(source.read_text())}

--- a/twig/utils/compiler.py
+++ b/twig/utils/compiler.py
@@ -1,9 +1,9 @@
 from typing import Any, Dict, Iterable
 
-from eth_utils import to_hex, to_tuple
+from eth_utils import to_tuple
 
 from ethpm.tools import builder as b
-from vyper import compiler
+from vyper import compile_code
 
 
 @to_tuple
@@ -25,12 +25,8 @@ def generate_contract_types(
 
 
 def create_raw_asset_data(source: str) -> Dict[str, Any]:
+    out = compile_code(source, ["bytecode", "abi"])
     return {
-        "abi": compiler.mk_full_signature(source),
-        "evm": {
-            "bytecode": {
-                "object": to_hex(compiler.compile(source)),
-                "linkReferences": {},
-            }
-        },
+        "abi": out["abi"],
+        "evm": {"bytecode": {"object": out["bytecode"], "linkReferences": {}}},
     }


### PR DESCRIPTION
## What was wrong?

Vyper changed things!

## How was it fixed?
Use `compile_code` for single files, `compile_codes` for multiple files.

#### Cute Animal Picture

![](https://images-na.ssl-images-amazon.com/images/I/616Vt2MhnIL._SX425_.jpg)
