### PR TITLE
Update compiler to include runtime bytecode & `Compiler.get_simple_manifest()`

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -33,9 +33,9 @@ Project setup
 .. code:: python
 
    @pytest.fixture
-   def my_contract_package(deployer):
+   def my_contract_package(twig_deployer):
        # returns an ethpm.Package instance loaded with a "my_contract" deployment on the ethpm.Package.w3 instance
-       return deployer.deploy("my_contract")
+       return twig_deployer.deploy("my_contract")
 
    @pytest.fixture
    def my_contract(my_contract_package):

--- a/setup.py
+++ b/setup.py
@@ -48,10 +48,11 @@ setup(
     url='https://github.com/ethereum/twig',
     include_package_data=True,
     install_requires=[
+        "eth-abi>=1.2.0,<1.3.0",
         "eth-utils>=1,<2",
         "eth-typing>=1,<2",
         "ethpm>=0.1.4a8,<1",
-        "pytest-ethereum>=0.1.3a3,<1",
+        "pytest-ethereum>=0.1.3a5,<1",
         "web3[tester]>=4.7,<5",
         "vyper>=0.1.0b5,<1",
     ],

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,8 @@ setup(
     install_requires=[
         "eth-utils>=1,<2",
         "eth-typing>=1,<2",
-        "ethpm>=0.1.4a7,<1",
-        "pytest-ethereum>=0.1.3a1,<1",
+        "ethpm>=0.1.4a8,<1",
+        "pytest-ethereum>=0.1.3a3,<1",
         "web3[tester]>=4.7,<5",
         "vyper>=0.1.0b5,<1",
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,5 +28,5 @@ def tmp_contracts(tmpdir):
 
 
 @pytest.fixture
-def deployer(twig_deployer):
-    return twig_deployer(CONTRACTS_DIR)
+def deployer(vy_deployer):
+    return vy_deployer(CONTRACTS_DIR)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,13 @@
+import json
 from pathlib import Path
 
 import pytest
 
 from twig import CONTRACTS_DIR
+from twig.backends import VyperBackend
+from twig.compiler import Compiler
+from twig.filesystem import collect_sources
 from web3 import Web3
-
-TEST_CONTRACTS_DIR = Path(__file__).parent / "assets"
 
 pytest_plugins = ["pytest_ethereum.plugins"]
 
@@ -18,15 +20,45 @@ def w3():
 
 
 @pytest.fixture
-def tmp_contracts(tmpdir):
-    contracts = TEST_CONTRACTS_DIR.glob("*.vy")
-    p = tmpdir.mkdir("contracts")
-    for contract in contracts:
-        tmp = p.join(contract.name)
-        tmp.write(contract.read_text())
-    return p
+def test_contracts_dir():
+    return Path(__file__).parent / "assets"
 
 
 @pytest.fixture
-def deployer(vy_deployer):
-    return vy_deployer(CONTRACTS_DIR)
+def test_contracts(test_contracts_dir):
+    return collect_sources(test_contracts_dir)
+
+
+@pytest.fixture
+def test_contracts_manifest(tmpdir, test_contracts):
+    vyper_backend = VyperBackend()
+    p = tmpdir.mkdir("test_contracts")
+    tmp = p.join("1.0.0.json")
+    manifest = Compiler(test_contracts, vyper_backend).get_simple_manifest(
+        "twig", "1.0.0"
+    )
+    tmp.write(json.dumps(manifest, sort_keys=True, separators=(",", ":")))
+    return Path(p) / "1.0.0.json"
+
+
+@pytest.fixture
+def twig_contracts_manifest(tmpdir):
+    vyper_backend = VyperBackend()
+    twig_contracts = collect_sources(CONTRACTS_DIR)
+    p = tmpdir.mkdir("twig_contracts")
+    tmp = p.join("1.0.0.json")
+    manifest = Compiler(twig_contracts, vyper_backend).get_simple_manifest(
+        "twig", "1.0.0"
+    )
+    tmp.write(json.dumps(manifest, sort_keys=True, separators=(",", ":")))
+    return Path(p) / "1.0.0.json"
+
+
+@pytest.fixture
+def test_deployer(deployer, test_contracts_manifest):
+    return deployer(test_contracts_manifest)
+
+
+@pytest.fixture
+def twig_deployer(deployer, twig_contracts_manifest):
+    return deployer(twig_contracts_manifest)

--- a/tests/core/test_compiler.py
+++ b/tests/core/test_compiler.py
@@ -28,9 +28,19 @@ def twig_deployer(compiler, w3):
 
 
 def test_compiler(compiler):
+    assert compiler.output is None
     assert len(compiler.get_source_tree()) == 3
     assert len(compiler.get_contract_types()) == 3
     assert isinstance(compiler.backend, VyperBackend)
+    assert compiler.output is not None
+    auction_data = [
+        data["simple_open_auction"]
+        for data in compiler.output.values()
+        if data.get("simple_open_auction")
+    ][0]
+    assert "evm" in auction_data
+    assert "bytecode" in auction_data["evm"]
+    assert "deployedBytecode" in auction_data["evm"]
 
 
 def test_compiler_creates_valid_registry_package_and_deployment(twig_deployer, w3):

--- a/tests/core/test_compiler.py
+++ b/tests/core/test_compiler.py
@@ -2,29 +2,15 @@ import logging
 
 import pytest
 
-from ethpm.tools import builder as b
-from pytest_ethereum.deployer import Deployer
 from twig.backends import VyperBackend
 from twig.compiler import Compiler
-from twig.filesystem import collect_sources
 
 logging.getLogger("evm").setLevel(logging.INFO)
 
 
 @pytest.fixture
-def compiler(tmp_contracts):
-    return Compiler(sources=collect_sources(tmp_contracts), backend=VyperBackend())
-
-
-@pytest.fixture
-def twig_deployer(compiler, w3):
-    # Return a Deployer containing all .vy contracts found
-    sources = compiler.get_source_tree()
-    contract_types = compiler.get_contract_types()
-    pkg = b.build(
-        b.init_manifest("twig", "1.0.0"), *sources, *contract_types, b.as_package(w3)
-    )
-    return Deployer(pkg)
+def compiler(test_contracts):
+    return Compiler(sources=test_contracts, backend=VyperBackend())
 
 
 def test_compiler(compiler):
@@ -43,16 +29,16 @@ def test_compiler(compiler):
     assert "deployedBytecode" in auction_data["evm"]
 
 
-def test_compiler_creates_valid_registry_package_and_deployment(twig_deployer, w3):
-    registry_package = twig_deployer.deploy("registry")
+def test_compiler_creates_valid_registry_package_and_deployment(test_deployer, w3):
+    registry_package = test_deployer.deploy("registry")
     registry_contract = registry_package.deployments.get_instance("registry")
     registry_contract.functions.register(b"xxx", w3.eth.accounts[0]).transact()
     actual = registry_contract.functions.lookup(b"xxx").call()
     assert actual == w3.eth.accounts[0]
 
 
-def test_compiler_creates_valid_auction_package_and_deployment(twig_deployer, w3):
-    auction_package = twig_deployer.deploy(
+def test_compiler_creates_valid_auction_package_and_deployment(test_deployer, w3):
+    auction_package = test_deployer.deploy(
         "simple_open_auction", w3.eth.accounts[0], 100
     )
     w3 = auction_package.w3

--- a/tests/core/test_filesystem.py
+++ b/tests/core/test_filesystem.py
@@ -1,8 +1,8 @@
 from twig.filesystem import collect_sources
 
 
-def test_collect_sources(tmp_contracts):
-    sources = collect_sources(tmp_contracts)
+def test_collect_sources(test_contracts_dir):
+    sources = collect_sources(test_contracts_dir)
     filenames = [source.name for source in sources]
     assert set(filenames) == set(
         ["registry.vy", "simple_open_auction.vy", "crowdfund.vy"]

--- a/tests/test_name_registry.py
+++ b/tests/test_name_registry.py
@@ -4,9 +4,9 @@ import pytest
 
 
 @pytest.fixture
-def name_registry_package(deployer):
+def name_registry_package(twig_deployer):
     # returns an ethpm.package instance loaded with a "name_registry" deployment
-    return deployer.deploy("name_registry")
+    return twig_deployer.deploy("name_registry")
 
 
 @pytest.fixture

--- a/twig/compiler.py
+++ b/twig/compiler.py
@@ -1,12 +1,15 @@
 from pathlib import Path
 from typing import Any, Dict, Sequence
 
+from ethpm.tools import builder as b
+from ethpm.typing import Manifest
 from twig.backends import VyperBackend
 from twig.exceptions import CompilerError
 from twig.utils.compiler import generate_contract_types, generate_inline_sources
 
 
 class Compiler:
+    # todo solidity backend - start from solc output &/or source contracts
     def __init__(self, sources: Sequence[Path], backend: VyperBackend) -> None:
         self.sources = sources
         self.backend = backend
@@ -28,3 +31,17 @@ class Compiler:
         if not self.output:
             self.compile()
         return generate_inline_sources(self.output)
+
+    def get_simple_manifest(self, name: str, version: str) -> Manifest:
+        composed_contract_types = self.get_contract_types()
+        composed_inline_sources = self.get_source_tree()
+        manifest = b.build(
+            {},
+            b.package_name(name),
+            b.version(version),
+            b.manifest_version("2"),
+            *composed_inline_sources,
+            *composed_contract_types,
+            b.validate(),
+        )
+        return manifest

--- a/twig/compiler.py
+++ b/twig/compiler.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Any, Dict, Sequence
 
 from twig.backends import VyperBackend
+from twig.exceptions import CompilerError
 from twig.utils.compiler import generate_contract_types, generate_inline_sources
 
 
@@ -12,6 +13,10 @@ class Compiler:
         self.output: Dict[str, Any] = None
 
     def compile(self) -> None:
+        if self.output:
+            raise CompilerError(
+                "This instance of Compiler already contains compiler output."
+            )
         self.output = self.backend.compile(self.sources)
 
     def get_contract_types(self) -> Dict[str, Any]:

--- a/twig/exceptions.py
+++ b/twig/exceptions.py
@@ -1,0 +1,14 @@
+class TwigError(Exception):
+    """
+    Base class for all Twig errors.
+    """
+
+    pass
+
+
+class CompilerError(TwigError):
+    """
+    Raised when an error occurs during compilation.
+    """
+
+    pass

--- a/twig/filesystem.py
+++ b/twig/filesystem.py
@@ -5,5 +5,4 @@ SOURCES_GLOB = "**/*.vy"
 
 
 def collect_sources(path: Path, glob: str = SOURCES_GLOB) -> Iterable[Path]:
-    all_sources = Path(path).glob(glob)
-    return all_sources
+    return Path(path).glob(glob)


### PR DESCRIPTION
## What was wrong?
Auto-generated vyper compiler output wasn't including the `runtime_bytecode`, which is fairly useful in certain situations - ex. verification of on-chain code

Wrote a `Compiler` method that will generate a quick-n-dirty manifest for the `Compiler` contracts

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/49373799-9ca5b900-f6ff-11e8-9e06-de297dd33e02.png)
